### PR TITLE
⚡ optimize book ID extraction in find_all

### DIFF
--- a/adapter/src/repository/book.rs
+++ b/adapter/src/repository/book.rs
@@ -126,7 +126,6 @@ impl BookRepository for BookRepositoryImpl {
         .map_err(AppError::DatabaseOperationError)?;
 
         // let items = rows.into_iter().map(Book::from).collect();
-        let book_ids = rows.iter().map(|book| book.book_id).collect::<Vec<_>>();
         let mut checkouts = self.find_checkouts(&book_ids).await?;
         let items = rows
             .into_iter()


### PR DESCRIPTION
### 💡 What
This optimization removes a redundant $O(N)$ loop and vector allocation in the `find_all` method of the `BookRepositoryImpl`.

### 🎯 Why
The code was previously extracting a vector of `BookId` from the result rows of a database query, even though the exact same IDs were already available in a `book_ids` vector created earlier in the same function. Removing this avoids unnecessary CPU cycles and memory allocations.

### 📊 Measured Improvement
Due to environment restrictions (missing toolchain and restricted internet access), direct benchmarking was not possible. However, the change is a clear algorithmic improvement by removing an $O(N)$ iteration and an $O(N)$ allocation, where $N$ is the number of books retrieved (up to the pagination limit). Reusing the existing vector is both safer and more efficient.

---
*PR created automatically by Jules for task [6453639452248116807](https://jules.google.com/task/6453639452248116807) started by @kurousa*