### PR TITLE
Refactor Header logout to use props and custom hook

### DIFF
--- a/frontend/app/_components/Header.tsx
+++ b/frontend/app/_components/Header.tsx
@@ -16,23 +16,14 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react";
 import NextLink from "next/link";
-import { useRouter } from "next/navigation";
-import useLocalStorageState from "use-local-storage-state";
-import { ACCESS_TOKEN_KEY } from "./auth";
 import { FC } from "react";
 import { useCurrentUser } from "../_contexts/user";
-import { post } from "../_lib/client";
 
-const Header: FC = () => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
-  const router = useRouter();
+type HeaderProps = {
+  onClickLogout: () => void;
+};
 
-  const onClickLogout = async () => {
-    // TODO: components内でリクエストを飛ばさないようにしたい。外からpropsで渡す。
-    await post({ destination: "/auth/logout", token: accessToken });
-    router.push("/login");
-  };
-
+const Header: FC<HeaderProps> = ({ onClickLogout }) => {
   const { currentUser } = useCurrentUser();
 
   return (

--- a/frontend/app/_contexts/user.ts
+++ b/frontend/app/_contexts/user.ts
@@ -1,8 +1,21 @@
 import useSWR from "swr";
 import useLocalStorageState from "use-local-storage-state";
 import { ACCESS_TOKEN_KEY } from "../_components/auth";
-import { fetchWithToken } from "../_lib/client";
+import { fetchWithToken, post } from "../_lib/client";
 import { User, Users } from "../_types/user";
+import { useRouter } from "next/navigation";
+
+export const useLogout = () => {
+  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
+  const router = useRouter();
+
+  const logout = async () => {
+    await post({ destination: "/auth/logout", token: accessToken });
+    router.push("/login");
+  };
+
+  return { logout };
+};
 
 export const useCurrentUser = () => {
   const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);

--- a/frontend/app/books/[id]/edit/page.tsx
+++ b/frontend/app/books/[id]/edit/page.tsx
@@ -3,6 +3,7 @@
 import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import Header from "@/app/_components/Header";
 import { useBook } from "@/app/_contexts/book";
+import { useLogout } from "@/app/_contexts/user";
 import { put } from "@/app/_lib/client";
 import {
   Button,
@@ -25,6 +26,7 @@ export default function EditBook({
 }>) {
   const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
+  const { logout } = useLogout();
 
   const { book } = useBook(params.id);
   const [input, setInput] = useState(
@@ -58,7 +60,7 @@ export default function EditBook({
 
   return (
     <>
-      <Header></Header>
+      <Header onClickLogout={logout}></Header>
       <Container maxW="container.xl" my={20}>
         <Heading as="h2" size="2xl" mb={2}>
           蔵書を編集する

--- a/frontend/app/books/[id]/page.tsx
+++ b/frontend/app/books/[id]/page.tsx
@@ -27,6 +27,7 @@ import { useRef } from "react";
 import useLocalStorageState from "use-local-storage-state";
 import NextLink from "next/link";
 import { useBook } from "@/app/_contexts/book";
+import { useLogout } from "@/app/_contexts/user";
 import { del } from "@/app/_lib/client";
 import CheckoutButton from "@/app/_components/CheckoutButton";
 import CheckoutHistory from "@/app/_components/CheckoutHistory";
@@ -34,6 +35,7 @@ import CheckoutHistory from "@/app/_components/CheckoutHistory";
 export default function Page({ params }: Readonly<{ params: { id: string } }>) {
   const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
+  const { logout } = useLogout();
   const {
     isOpen: isOpenDelete,
     onOpen: onOpenDelete,
@@ -56,7 +58,7 @@ export default function Page({ params }: Readonly<{ params: { id: string } }>) {
 
   return (
     <>
-      <Header />
+      <Header onClickLogout={logout} />
       <Container maxW="container.xl" my={20}>
         <Heading as="h2" size="2xl" mb={4} noOfLines={1}>
           書籍情報 : {book?.title}

--- a/frontend/app/books/checkouts/me/page.tsx
+++ b/frontend/app/books/checkouts/me/page.tsx
@@ -4,14 +4,16 @@ import BookTable from "@/app/_components/BookTable";
 import Header from "@/app/_components/Header";
 import ReturnButton from "@/app/_components/ReturnButton";
 import { useMyCheckouts } from "@/app/_contexts/checkout";
+import { useLogout } from "@/app/_contexts/user";
 import { Box, Container, Heading, Text } from "@chakra-ui/react";
 
 export default function CheckedOutBookList() {
   const { checkouts } = useMyCheckouts();
+  const { logout } = useLogout();
 
   return (
     <>
-      <Header></Header>
+      <Header onClickLogout={logout}></Header>
       <Container maxW="container.xl" my={20}>
         <Heading as="h2" size="2xl" mb={10}>
           借りている蔵書

--- a/frontend/app/books/checkouts/page.tsx
+++ b/frontend/app/books/checkouts/page.tsx
@@ -4,16 +4,17 @@ import BookTable from "@/app/_components/BookTable";
 import Header from "@/app/_components/Header";
 import ReturnButton from "@/app/_components/ReturnButton";
 import { useCheckouts } from "@/app/_contexts/checkout";
-import { useCurrentUser } from "@/app/_contexts/user";
+import { useCurrentUser, useLogout } from "@/app/_contexts/user";
 import { Box, Container, Heading, Text } from "@chakra-ui/react";
 
 export default function CheckedOutBookList() {
   const { checkouts } = useCheckouts();
   const { currentUser } = useCurrentUser();
+  const { logout } = useLogout();
 
   return (
     <>
-      <Header></Header>
+      <Header onClickLogout={logout}></Header>
       <Container maxW="container.xl" my={20}>
         <Heading as="h2" size="2xl" mb={10}>
           貸出中の蔵書

--- a/frontend/app/books/create/page.tsx
+++ b/frontend/app/books/create/page.tsx
@@ -2,6 +2,7 @@
 
 import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import Header from "@/app/_components/Header";
+import { useLogout } from "@/app/_contexts/user";
 import { post } from "@/app/_lib/client";
 import {
   Button,
@@ -27,6 +28,7 @@ type BookInput = {
 export default function CreateBook() {
   const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
+  const { logout } = useLogout();
 
   const {
     handleSubmit,
@@ -48,7 +50,7 @@ export default function CreateBook() {
 
   return (
     <>
-      <Header></Header>
+      <Header onClickLogout={logout}></Header>
       <Container maxW="container.xl" my={20}>
         <Heading as="h2" size="2xl" mb={2}>
           新しい蔵書を登録する

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -24,6 +24,7 @@ import { FC } from "react";
 import NextLink from "next/link";
 import { Book } from "./_types/book";
 import { useBooks } from "./_contexts/book";
+import { useLogout } from "./_contexts/user";
 import { NextPage } from "next";
 import Pagination from "./_components/Pagination";
 
@@ -44,10 +45,11 @@ const Home: NextPage = ({
   const limit = books?.limit ?? BOOKS_PER_PAGE;
   const offset = books?.offset ?? 0;
   const total = books?.total ?? 0;
+  const { logout } = useLogout();
 
   return (
     <>
-      <Header></Header>
+      <Header onClickLogout={logout}></Header>
       <Container maxW="container.xl" my={20}>
         <Pagination limit={limit} offset={offset} total={total} />
 

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -2,17 +2,18 @@
 
 import Header from "@/app/_components/Header";
 import { Container, Heading, Stack, Text } from "@chakra-ui/react";
-import { useCurrentUser, useUsers } from "@/app/_contexts/user";
+import { useCurrentUser, useLogout, useUsers } from "@/app/_contexts/user";
 import UserTable from "@/app/_components/UserTable";
 import AddUserButton from "@/app/_components/AddUserButton";
 
 export default function ListUser() {
   const { currentUser } = useCurrentUser();
   const { users } = useUsers();
+  const { logout } = useLogout();
 
   return (
     <>
-      <Header></Header>
+      <Header onClickLogout={logout}></Header>
       <Container maxW="container.xl" my={20}>
         <Heading as="h2" size="2xl" mb={2}>
           ユーザー一覧

--- a/frontend/app/users/password/page.tsx
+++ b/frontend/app/users/password/page.tsx
@@ -2,6 +2,7 @@
 
 import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import Header from "@/app/_components/Header";
+import { useLogout } from "@/app/_contexts/user";
 import {
   Button,
   Container,
@@ -30,6 +31,7 @@ export default function UpdateUserPassword() {
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
+  const { logout } = useLogout();
   const toast = useToast();
 
   const {
@@ -68,7 +70,7 @@ export default function UpdateUserPassword() {
 
   return (
     <>
-      <Header></Header>
+      <Header onClickLogout={logout}></Header>
       <Container maxW="container.xl" my={20}>
         <Heading as="h2" size="2xl" mb={2}>
           パスワード変更


### PR DESCRIPTION
The `Header` component was making API requests and handling navigation directly for the logout functionality. This change refactors the component to be more presentational by accepting an `onClickLogout` prop. 

To maintain dry principles, a `useLogout` hook was introduced in the user context, which encapsulates the logic for calling the logout endpoint and redirecting to the login page. All eight pages that consume the `Header` component were updated to use this hook and pass the logout handler to the `Header`.

---
*PR created automatically by Jules for task [13825719858173945442](https://jules.google.com/task/13825719858173945442) started by @kurousa*