### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ sqlx = { version = "0.8.1", features = [ # Updated to address RUSTSEC-2024-0363
     "runtime-tokio",
     "uuid",
     "chrono",
-    # "macros", # Temporarily removed
-    # "offline", # Temporarily removed
+    # "macros",
+    # "offline",
     "postgres",
     "migrate",
 ] }

--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -96,7 +96,12 @@ async fn bootstrap() -> Result<()> {
         // allow `GET`,`POST`,`PUT`,`DELETE` when accessing the resource
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
         // allow requests from any origin
-        .allow_origin(cors::Any);
+        .allow_origin(
+            std::env::var("FRONTEND_URL")
+                .unwrap_or_else(|_| "http://localhost:3000".into())
+                .parse::<axum::http::HeaderValue>()
+                .unwrap(),
+        );
 
     let router = Router::new().merge(v1::routes()).merge(auth::routes());
     // デバッグビルドの時は, ReDocによるAPIドキュメント出力を有効にする

--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -100,7 +100,7 @@ async fn bootstrap() -> Result<()> {
             std::env::var("FRONTEND_URL")
                 .unwrap_or_else(|_| "http://localhost:3000".into())
                 .parse::<axum::http::HeaderValue>()
-                .unwrap(),
+                .context("FRONTEND_URL must be a valid header value")?
         );
 
     let router = Router::new().merge(v1::routes()).merge(auth::routes());

--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -100,7 +100,7 @@ async fn bootstrap() -> Result<()> {
             std::env::var("FRONTEND_URL")
                 .unwrap_or_else(|_| "http://localhost:3000".into())
                 .parse::<axum::http::HeaderValue>()
-                .context("FRONTEND_URL must be a valid header value")?
+                .unwrap(),
         );
 
     let router = Router::new().merge(v1::routes()).merge(auth::routes());


### PR DESCRIPTION
🎯 **What:** The application's CORS policy was overly permissive, allowing requests from any origin (`cors::Any`).
⚠️ **Risk:** This could allow a malicious website to make unauthorized cross-origin requests to the API, potentially leading to CSRF or other attacks depending on endpoint authentication mechanisms.
🛡️ **Solution:** Restricted the allowed origins to a specific domain by reading the `FRONTEND_URL` environment variable, defaulting to `http://localhost:3000` if unset. This ensures only trusted frontend applications can interact with the API.

---
*PR created automatically by Jules for task [13191520519166060895](https://jules.google.com/task/13191520519166060895) started by @kurousa*