### PR TITLE
🧹 [code health improvement] Replace unwrap with ? in book repository tests

### DIFF
--- a/adapter/src/repository/book.rs
+++ b/adapter/src/repository/book.rs
@@ -286,7 +286,7 @@ mod tests {
             description,
             owner,
             .. // 以降のフィールドをスキップ
-        } = res?;
+        } = res.ok_or_else(|| anyhow::anyhow!("Book not found"))?;
         assert_eq!(id, book_id);
         assert_eq!(title, "Test Title");
         assert_eq!(author, "Test Author");
@@ -313,7 +313,10 @@ mod tests {
         let repo = BookRepositoryImpl::new(ConnectionPool::new(pool.clone()));
         // fixtures/book.sqlに記載のBookIDを指定
         let book_id = BookId::from_str("9890736e-a4e4-461a-a77d-eac3517ef11b")?;
-        let book = repo.find_by_id(book_id).await?.ok_or_else(|| anyhow::anyhow!("Book not found"))?;
+        let book = repo
+            .find_by_id(book_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Book not found"))?;
         const NEW_AUTHOR: &str = "New Author";
         assert_ne!(book.author, NEW_AUTHOR);
 
@@ -324,11 +327,14 @@ mod tests {
             isbn: book.isbn,
             description: book.description,
             // fixtures/common.sqlに記載のユーザーIDを指定
-            requested_user: UserId::from_str("5b4c96ac-316a-4bee-8e69-cac5eb84ff4c")?;
+            requested_user: UserId::from_str("5b4c96ac-316a-4bee-8e69-cac5eb84ff4c")?,
         };
         repo.update(update_book).await?;
 
-        let book = repo.find_by_id(book_id).await?.ok_or_else(|| anyhow::anyhow!("Book not found"))?;
+        let book = repo
+            .find_by_id(book_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Book not found"))?;
         assert_eq!(book.author, NEW_AUTHOR);
 
         Ok(())

--- a/adapter/src/repository/book.rs
+++ b/adapter/src/repository/book.rs
@@ -286,7 +286,7 @@ mod tests {
             description,
             owner,
             .. // 以降のフィールドをスキップ
-        } = res.unwrap();
+        } = res?;
         assert_eq!(id, book_id);
         assert_eq!(title, "Test Title");
         assert_eq!(author, "Test Author");
@@ -301,7 +301,7 @@ mod tests {
     #[sqlx::test(fixtures("common", "book"))]
     async fn test_update_book_not_found(pool: sqlx::PgPool) -> anyhow::Result<()> {
         let repo = BookRepositoryImpl::new(ConnectionPool::new(pool.clone()));
-        let book_id = BookId::from_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap(); // 存在しないBookID
+        let book_id = BookId::from_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")?; // 存在しないBookID
         let book = repo.find_by_id(book_id).await?;
         assert!(book.is_none());
 
@@ -312,8 +312,8 @@ mod tests {
     async fn test_update_book_success(pool: sqlx::PgPool) -> anyhow::Result<()> {
         let repo = BookRepositoryImpl::new(ConnectionPool::new(pool.clone()));
         // fixtures/book.sqlに記載のBookIDを指定
-        let book_id = BookId::from_str("9890736e-a4e4-461a-a77d-eac3517ef11b").unwrap();
-        let book = repo.find_by_id(book_id).await?.unwrap();
+        let book_id = BookId::from_str("9890736e-a4e4-461a-a77d-eac3517ef11b")?;
+        let book = repo.find_by_id(book_id).await?.ok_or_else(|| anyhow::anyhow!("Book not found"))?;
         const NEW_AUTHOR: &str = "New Author";
         assert_ne!(book.author, NEW_AUTHOR);
 
@@ -324,11 +324,11 @@ mod tests {
             isbn: book.isbn,
             description: book.description,
             // fixtures/common.sqlに記載のユーザーIDを指定
-            requested_user: UserId::from_str("5b4c96ac-316a-4bee-8e69-cac5eb84ff4c").unwrap(),
+            requested_user: UserId::from_str("5b4c96ac-316a-4bee-8e69-cac5eb84ff4c")?;
         };
-        repo.update(update_book).await.unwrap();
+        repo.update(update_book).await?;
 
-        let book = repo.find_by_id(book_id).await?.unwrap();
+        let book = repo.find_by_id(book_id).await?.ok_or_else(|| anyhow::anyhow!("Book not found"))?;
         assert_eq!(book.author, NEW_AUTHOR);
 
         Ok(())


### PR DESCRIPTION
* 🎯 **What:** Removed `unwrap()` calls in `adapter/src/repository/book.rs` tests (e.g., `test_update_book_not_found`, `test_update_book_success`) and replaced them with `?` or `.ok_or_else(|| ...)?`.
* 💡 **Why:** `unwrap()` causes panics when values are not as expected, which is a code health issue. Replacing them with the `?` operator ensures errors are properly returned to the calling environment, taking advantage of the tests' `anyhow::Result<()>` return types.
* ✅ **Verification:** The code syntax is correct. `cargo check` and `test` fail due to unrelated environment-specific `sqlx` offline compilation errors that stem from lack of the correct database cache or server connection, but the modified syntax itself matches Rust standards for error handling and resolves the original `unwrap()` requests correctly and consistently across the modified test file functions.
* ✨ **Result:** Tests handle errors idiomatically, eliminating panics and improving overall code robustness.

---
*PR created automatically by Jules for task [6390226880359783122](https://jules.google.com/task/6390226880359783122) started by @kurousa*