### PR TITLE
⚡ optimize: parallelize checkout history queries in CheckoutRepositoryImpl

### DIFF
--- a/adapter/Cargo.toml
+++ b/adapter/Cargo.toml
@@ -19,3 +19,4 @@ derive-new.workspace = true
 sqlx.workspace = true
 redis.workspace = true
 anyhow.workspace = true
+tokio.workspace = true

--- a/adapter/src/repository/checkout.rs
+++ b/adapter/src/repository/checkout.rs
@@ -320,7 +320,10 @@ impl CheckoutRepository for CheckoutRepositoryImpl {
     // 特定蔵書の貸出履歴(返却済みも含む)を取得する
     async fn find_history_by_book_id(&self, book_id: BookId) -> AppResult<Vec<Checkout>> {
         // 未返却の貸出と返却済みの貸出履歴を並行して取得する
-        let (unreturned_co_res, returned_checkout_rows_res) = tokio::join!(
+        let (unreturned_co_res, returned_checkout_rows_res): (
+            AppResult<Option<Checkout>>,
+            Result<Vec<ReturnedCheckoutRow>, sqlx::Error>,
+        ) = tokio::join!(
             self.find_unreturned_by_book_id(book_id),
             sqlx::query_as!(
                 ReturnedCheckoutRow,

--- a/adapter/src/repository/checkout.rs
+++ b/adapter/src/repository/checkout.rs
@@ -319,13 +319,12 @@ impl CheckoutRepository for CheckoutRepositoryImpl {
 
     // 特定蔵書の貸出履歴(返却済みも含む)を取得する
     async fn find_history_by_book_id(&self, book_id: BookId) -> AppResult<Vec<Checkout>> {
-        // 未返却の貸出を取得
-        let unreturned_co: Option<Checkout> = self.find_unreturned_by_book_id(book_id).await?;
-
-        // 返却済みの貸出し情報を取得する
-        let mut checkout_histories: Vec<Checkout> = sqlx::query_as!(
-            ReturnedCheckoutRow,
-            r#"
+        // 未返却の貸出と返却済みの貸出履歴を並行して取得する
+        let (unreturned_co_res, returned_checkout_rows_res) = tokio::join!(
+            self.find_unreturned_by_book_id(book_id),
+            sqlx::query_as!(
+                ReturnedCheckoutRow,
+                r#"
                 SELECT
                     rc.checkout_id,
                     rc.book_id,
@@ -342,14 +341,17 @@ impl CheckoutRepository for CheckoutRepositoryImpl {
                     rc.book_id = $1
                 ORDER BY rc.returned_at DESC
             "#,
-            book_id as _,
-        )
-        .fetch_all(self.db.inner_ref())
-        .await
-        .map_err(AppError::DatabaseOperationError)?
-        .into_iter()
-        .map(Checkout::from)
-        .collect();
+                book_id as _,
+            )
+            .fetch_all(self.db.inner_ref())
+        );
+
+        let unreturned_co = unreturned_co_res?;
+        let mut checkout_histories: Vec<Checkout> = returned_checkout_rows_res
+            .map_err(AppError::DatabaseOperationError)?
+            .into_iter()
+            .map(Checkout::from)
+            .collect();
 
         // 貸出中である場合は、返却済みの履歴の先頭に追加
         if let Some(co) = unreturned_co {


### PR DESCRIPTION
The `find_history_by_book_id` function was previously performing two database queries sequentially: one to fetch unreturned checkouts and another for returned checkout history. These queries are independent and can be executed concurrently in an async context.

**Optimization implemented:**
- Used `tokio::join!` to concurrently execute both database queries.
- This allows the database to process both requests in parallel (subject to connection pool capacity), reducing the total time spent waiting for I/O.

**Measured Improvement:**
- While local benchmarking was not possible due to environment restrictions (missing dependencies in the offline cache), this is a standard optimization for I/O-bound async tasks that is expected to reduce latency for this endpoint by up to the duration of the shorter of the two queries.

**Safety:**
- Both queries only require an immutable reference to `self` (`&self`), which is safe to share between concurrent futures in Rust.
- Error handling remains consistent, as the function returns an error if either query fails.

---
*PR created automatically by Jules for task [10481625670568301562](https://jules.google.com/task/10481625670568301562) started by @kurousa*