### PR TITLE
🧹 Remove commented-out dead code in BookRepositoryImpl::find_all

### DIFF
--- a/adapter/src/repository/book.rs
+++ b/adapter/src/repository/book.rs
@@ -125,7 +125,6 @@ impl BookRepository for BookRepositoryImpl {
         .await
         .map_err(AppError::DatabaseOperationError)?;
 
-        // let items = rows.into_iter().map(Book::from).collect();
         let mut checkouts = self.find_checkouts(&book_ids).await?;
         let items = rows
             .into_iter()


### PR DESCRIPTION
🎯 **What:** Removed a line of commented-out dead code in `adapter/src/repository/book.rs`.
💡 **Why:** The commented-out code `// let items = rows.into_iter().map(Book::from).collect();` was obsolete and its functionality had been replaced by the subsequent logic that handles checkouts. Removing it improves code readability and maintainability.
✅ **Verification:** Manually verified that the code following the removed comment correctly implements the intended logic. Confirmed that there is no `From<BookRow> for Book` implementation in the codebase, which makes the commented-out code non-functional anyway.
✨ **Result:** A cleaner and more maintainable `find_all` method in the book repository.

---
*PR created automatically by Jules for task [7162171432336966233](https://jules.google.com/task/7162171432336966233) started by @kurousa*