### PR TITLE
🔒 [security fix] Migrate from localStorage to HttpOnly cookies for access token storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ sqlx = { version = "0.8.1", features = [ # Updated to address RUSTSEC-2024-0363
 ] }
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.44"
+time = "0.3.36"
 tokio = { version = "1.38.0", features = ["full"] } # Updated tokio
 mockall = "0.11.4"
 redis = { version = "0.25.3", features = ["tokio-rustls-comp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ bcrypt = "0.15.0"
 itertools = "0.11.0"
 tower = { version = "0.4.13", features = ["full"] }
 tracing = { version = "0.1.37", features = ["log"] }
-axum-extra = { version = "0.9.3", features = ["typed-header"] }
+axum-extra = { version = "0.9.3", features = ["typed-header", "cookie"] }
 tokio-stream = "0.1.14"
 garde = { version = "0.18.0", features = [
     "derive",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,6 +16,7 @@ registry.workspace = true
 axum.workspace = true
 derive-new.workspace = true
 chrono.workspace = true
+time.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tower.workspace = true

--- a/api/src/extractor.rs
+++ b/api/src/extractor.rs
@@ -1,8 +1,5 @@
-use axum::{async_trait, extract::FromRequestParts, http::request::Parts, RequestPartsExt};
-use axum_extra::{
-    headers::{authorization::Bearer, Authorization},
-    TypedHeader,
-};
+use axum::{async_trait, extract::FromRequestParts, http::request::Parts};
+use axum_extra::extract::CookieJar;
 use kernel::model::{auth::AccessToken, id::UserId, role::Role, user::User};
 use registry::AppRegistry;
 use shared::error::AppError;
@@ -29,12 +26,14 @@ impl FromRequestParts<AppRegistry> for AuthorizedUser {
         parts: &mut Parts,
         registry: &AppRegistry,
     ) -> Result<Self, Self::Rejection> {
-        // HTTPヘッダー"Authorization"からトークン(Bearer)を取得
-        let TypedHeader(Authorization(bearer)) = parts
-            .extract::<TypedHeader<Authorization<Bearer>>>()
+        let jar = CookieJar::from_request_parts(parts, registry)
             .await
             .map_err(|_| AppError::UnauthorizedError)?;
-        let access_token = AccessToken(bearer.token().to_string());
+
+        let access_token = jar
+            .get("access_token")
+            .map(|cookie| AccessToken(cookie.value().to_string()))
+            .ok_or(AppError::UnauthorizedError)?;
 
         // トークンからユーザーIDを取得
         let user_id = registry

--- a/api/src/handler/auth.rs
+++ b/api/src/handler/auth.rs
@@ -46,10 +46,7 @@ pub async fn login(
 
     Ok((
         jar.add(cookie),
-        Json(AccessTokenResponse {
-            user_id,
-            access_token: access_token.0,
-        }),
+        Json(AccessTokenResponse { user_id }),
     ))
 }
 /// ログアウト処理
@@ -76,7 +73,7 @@ pub async fn logout(
 
     let cookie = Cookie::build(("access_token", ""))
         .path("/")
-        .max_age(chrono::Duration::zero().to_std().unwrap().into())
+        .max_age(time::Duration::ZERO)
         .build();
 
     Ok((jar.add(cookie), StatusCode::NO_CONTENT))

--- a/api/src/handler/auth.rs
+++ b/api/src/handler/auth.rs
@@ -70,9 +70,7 @@ pub async fn logout(
 
     let cookie = Cookie::build(("access_token", ""))
         .path("/")
-        .max_age(axum_extra::extract::cookie::Expiration::from(
-            time::Duration::ZERO,
-        ))
+        .max_age(time::Duration::ZERO)
         .build();
 
     Ok((jar.add(cookie), StatusCode::NO_CONTENT))

--- a/api/src/handler/auth.rs
+++ b/api/src/handler/auth.rs
@@ -1,4 +1,6 @@
 use axum::{extract::State, http::StatusCode, Json};
+use axum_extra::extract::cookie::{Cookie, SameSite};
+use axum_extra::extract::CookieJar;
 use kernel::model::auth::event::CreateToken;
 use registry::AppRegistry;
 use shared::error::AppResult;
@@ -23,8 +25,9 @@ use crate::{
 )]
 pub async fn login(
     State(registry): State<AppRegistry>,
+    jar: CookieJar,
     Json(req): Json<LoginRequest>,
-) -> AppResult<Json<AccessTokenResponse>> {
+) -> AppResult<(CookieJar, Json<AccessTokenResponse>)> {
     let user_id = registry
         .auth_repository()
         .verify_user(&req.email, &req.password)
@@ -34,10 +37,20 @@ pub async fn login(
         .create_token(CreateToken::new(user_id))
         .await?;
 
-    Ok(Json(AccessTokenResponse {
-        user_id,
-        access_token: access_token.0,
-    }))
+    let cookie = Cookie::build(("access_token", access_token.0.clone()))
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Lax)
+        .path("/")
+        .build();
+
+    Ok((
+        jar.add(cookie),
+        Json(AccessTokenResponse {
+            user_id,
+            access_token: access_token.0,
+        }),
+    ))
 }
 /// ログアウト処理
 /// ユーザーのアクセストークンを削除する
@@ -54,10 +67,17 @@ pub async fn login(
 pub async fn logout(
     user: AuthorizedUser,
     State(registry): State<AppRegistry>,
-) -> AppResult<StatusCode> {
+    jar: CookieJar,
+) -> AppResult<(CookieJar, StatusCode)> {
     registry
         .auth_repository()
         .delete_token(user.access_token)
         .await?;
-    Ok(StatusCode::NO_CONTENT)
+
+    let cookie = Cookie::build(("access_token", ""))
+        .path("/")
+        .max_age(chrono::Duration::zero().to_std().unwrap().into())
+        .build();
+
+    Ok((jar.add(cookie), StatusCode::NO_CONTENT))
 }

--- a/api/src/handler/auth.rs
+++ b/api/src/handler/auth.rs
@@ -44,10 +44,7 @@ pub async fn login(
         .path("/")
         .build();
 
-    Ok((
-        jar.add(cookie),
-        Json(AccessTokenResponse { user_id }),
-    ))
+    Ok((jar.add(cookie), Json(AccessTokenResponse { user_id })))
 }
 /// ログアウト処理
 /// ユーザーのアクセストークンを削除する
@@ -73,7 +70,9 @@ pub async fn logout(
 
     let cookie = Cookie::build(("access_token", ""))
         .path("/")
-        .max_age(time::Duration::ZERO)
+        .max_age(axum_extra::extract::cookie::Expiration::from(
+            time::Duration::ZERO,
+        ))
         .build();
 
     Ok((jar.add(cookie), StatusCode::NO_CONTENT))

--- a/api/src/model/auth.rs
+++ b/api/src/model/auth.rs
@@ -16,5 +16,4 @@ pub struct LoginRequest {
 #[serde(rename_all = "camelCase")]
 pub struct AccessTokenResponse {
     pub user_id: UserId,
-    pub access_token: String,
 }

--- a/api/tests/api/book.rs
+++ b/api/tests/api/book.rs
@@ -63,7 +63,7 @@ async fn show_book_list_with_query_200(
     let app: axum::Router = make_router(fixture);
 
     // リクエストを作成・送信し、レスポンスのステータスコードを検証
-    let req = Request::get(&v1(path)).bearer().body(Body::empty())?;
+    let req = Request::get(&v1(path)).cookie().body(Body::empty())?;
     let resp = app.oneshot(req).await?;
     assert_eq!(resp.status(), axum::http::StatusCode::OK);
 
@@ -117,7 +117,7 @@ async fn show_book_list_with_query_400(
     let app: axum::Router = make_router(fixture);
 
     // リクエストを作成・送信し、レスポンスのステータスコードを検証
-    let req = Request::get(&v1(path)).bearer().body(Body::empty())?;
+    let req = Request::get(&v1(path)).cookie().body(Body::empty())?;
     let resp = app.oneshot(req).await?;
     assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
 

--- a/api/tests/api/helper.rs
+++ b/api/tests/api/helper.rs
@@ -64,11 +64,16 @@ pub fn fixture(mut fixture_auth: MockAppRegistryExt) -> MockAppRegistryExt {
 
 pub trait TestRequestExt {
     fn bearer(self) -> Builder;
+    fn cookie(self) -> Builder;
 }
 
 impl TestRequestExt for Builder {
     fn bearer(self) -> Builder {
         self.header("Authorization", "Bearer dummy")
+    }
+
+    fn cookie(self) -> Builder {
+        self.header("Cookie", "access_token=dummy")
     }
 }
 

--- a/frontend/app/_components/AddUserButton.tsx
+++ b/frontend/app/_components/AddUserButton.tsx
@@ -1,4 +1,3 @@
-import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import React, { FC, useState } from "react";
 import {
   Modal,
@@ -18,7 +17,6 @@ import {
   useToast,
   FormErrorMessage,
 } from "@chakra-ui/react";
-import useLocalStorageState from "use-local-storage-state";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { post } from "../_lib/client";
 import { useSWRConfig } from "swr";
@@ -33,7 +31,6 @@ const AddUserButton: FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [userInput, setUserInput] = useState<UserInput | null>(null);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false); // 成功メッセージモーダルの表示制御
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const toast = useToast();
   const { mutate } = useSWRConfig();
 
@@ -47,7 +44,6 @@ const AddUserButton: FC = () => {
   const onSubmit: SubmitHandler<UserInput> = async (values) => {
     const res = await post({
       destination: "/api/v1/users",
-      token: accessToken,
       body: values,
     });
 
@@ -56,7 +52,7 @@ const AddUserButton: FC = () => {
       reset();
       onClose();
       setIsSuccessModalOpen(true);
-      mutate(["/api/v1/users", accessToken]);
+      mutate("/api/v1/users");
     } else {
       toast({
         title: "ユーザーを作成できませんでした",

--- a/frontend/app/_components/CheckoutButton.tsx
+++ b/frontend/app/_components/CheckoutButton.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import { Book } from "../_types/book";
 import { useRouter } from "next/navigation";
-import useLocalStorageState from "use-local-storage-state";
 import { post, put } from "../_lib/client";
 import { useCurrentUser } from "../_contexts/user";
 import { Button } from "@chakra-ui/react";
@@ -17,7 +15,6 @@ export type CheckoutButtonProps = {
 const CheckoutButton: FC<CheckoutButtonProps> = ({
   book,
 }: CheckoutButtonProps) => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
   const { currentUser } = useCurrentUser();
   const { mutate } = useSWRConfig();
@@ -26,12 +23,11 @@ const CheckoutButton: FC<CheckoutButtonProps> = ({
     e.preventDefault();
     const res = await post({
       destination: `/api/v1/books/${book.id}/checkouts`,
-      token: accessToken,
     });
 
     if (res.ok) {
-      mutate([`/api/v1/books/${book.id}`, accessToken]);
-      mutate([`/api/v1/books/${book.id}/checkout-history`, accessToken]);
+      mutate(`/api/v1/books/${book.id}`);
+      mutate(`/api/v1/books/${book.id}/checkout-history`);
       router.refresh();
     }
   };
@@ -40,12 +36,11 @@ const CheckoutButton: FC<CheckoutButtonProps> = ({
     e.preventDefault();
     const res = await put({
       destination: `/api/v1/books/${book.id}/checkouts/${book.checkout?.id}`,
-      token: accessToken,
     });
 
     if (res.ok) {
-      mutate([`/api/v1/books/${book.id}`, accessToken]);
-      mutate([`/api/v1/books/${book.id}/checkout-history`, accessToken]);
+      mutate(`/api/v1/books/${book.id}`);
+      mutate(`/api/v1/books/${book.id}/checkout-history`);
       router.refresh();
     }
   };

--- a/frontend/app/_components/DeleteUserButton.tsx
+++ b/frontend/app/_components/DeleteUserButton.tsx
@@ -1,5 +1,4 @@
 import { FC, useRef } from "react";
-import { ACCESS_TOKEN_KEY } from "./auth";
 import {
   AlertDialog,
   AlertDialogBody,
@@ -13,7 +12,6 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { DeleteIcon } from "@chakra-ui/icons";
-import useLocalStorageState from "use-local-storage-state";
 import { User } from "../_types/user";
 import { del } from "../_lib/client";
 import { useSWRConfig } from "swr";
@@ -25,7 +23,6 @@ type DeleteUserButtonProps = {
 const DeleteUserButton: FC<DeleteUserButtonProps> = ({
   user,
 }: DeleteUserButtonProps) => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const { isOpen, onOpen, onClose } = useDisclosure({ id: "delete-book" });
   const toast = useToast();
   const cancelRef = useRef(null);
@@ -34,7 +31,6 @@ const DeleteUserButton: FC<DeleteUserButtonProps> = ({
   const handleDelete = async () => {
     const res = await del({
       destination: `/api/v1/users/${user.id}`,
-      token: accessToken,
     });
 
     if (res.ok) {
@@ -46,7 +42,7 @@ const DeleteUserButton: FC<DeleteUserButtonProps> = ({
         isClosable: true,
       });
       onClose();
-      mutate(["/api/v1/users", accessToken]);
+      mutate("/api/v1/users");
     } else {
       toast({
         title: "ユーザーを削除できませんでした",

--- a/frontend/app/_components/ReturnButton.tsx
+++ b/frontend/app/_components/ReturnButton.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import { Checkout } from "../_types/book";
-import useLocalStorageState from "use-local-storage-state";
 import { put } from "../_lib/client";
 import { Button, useToast } from "@chakra-ui/react";
 import { useSWRConfig } from "swr";
@@ -15,7 +13,6 @@ export type ReturnButtonProps = {
 const ReturnButton: FC<ReturnButtonProps> = ({
   checkout,
 }: ReturnButtonProps) => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const { mutate } = useSWRConfig();
   const toast = useToast();
 
@@ -23,7 +20,6 @@ const ReturnButton: FC<ReturnButtonProps> = ({
     e.preventDefault();
     const res = await put({
       destination: `/api/v1/books/${checkout.book.id}/checkouts/${checkout.id}/returned`,
-      token: accessToken,
     });
 
     if (res.ok) {
@@ -35,8 +31,8 @@ const ReturnButton: FC<ReturnButtonProps> = ({
         isClosable: true,
       });
 
-      mutate(["/api/v1/users/me/checkouts", accessToken]);
-      mutate(["/api/v1/books/checkouts", accessToken]);
+      mutate("/api/v1/users/me/checkouts");
+      mutate("/api/v1/books/checkouts");
     } else {
       toast({
         title: "蔵書を返却できませんでした",

--- a/frontend/app/_components/UpdateUserRoleSelector.tsx
+++ b/frontend/app/_components/UpdateUserRoleSelector.tsx
@@ -1,6 +1,4 @@
 import { Select, useToast } from "@chakra-ui/react";
-import useLocalStorageState from "use-local-storage-state";
-import { ACCESS_TOKEN_KEY } from "./auth";
 import { User } from "../_types/user";
 import { useSWRConfig } from "swr";
 import { put } from "../_lib/client";
@@ -15,14 +13,12 @@ const UpdateUserRoleSelector: FC<UpdateUserRoleSelectorProps> = ({
   user,
   isCurrentUser,
 }: UpdateUserRoleSelectorProps) => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const toast = useToast();
   const { mutate } = useSWRConfig();
 
   const handleUpdateRole = async (role: string) => {
     const res = await put({
       destination: `/api/v1/users/${user.id}/role`,
-      token: accessToken,
       body: { role: role },
     });
 
@@ -35,7 +31,7 @@ const UpdateUserRoleSelector: FC<UpdateUserRoleSelectorProps> = ({
           duration: 5000,
           isClosable: true,
         });
-        mutate(["/api/v1/users", accessToken]);
+        mutate("/api/v1/users");
       } else {
         toast({
           title: "ユーザーのロールを更新できませんでした",

--- a/frontend/app/_components/auth.ts
+++ b/frontend/app/_components/auth.ts
@@ -1,11 +1,15 @@
 import { redirect } from "next/navigation";
 import { FC } from "react";
-import useLocalStorageState from "use-local-storage-state";
+import { useCurrentUser } from "../_contexts/user";
 
 const AuthProvider: FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
+  const { currentUser, isLoading, isError } = useCurrentUser();
 
-  if (accessToken === undefined) {
+  if (isLoading) {
+    return null;
+  }
+
+  if (isError || !currentUser) {
     redirect("/login");
   }
 
@@ -13,11 +17,3 @@ const AuthProvider: FC<{ children: React.ReactNode }> = ({ children }) => {
 };
 
 export default AuthProvider;
-
-export const ACCESS_TOKEN_KEY = (() => {
-  const key = process.env.NEXT_PUBLIC_ACCESS_TOKEN_KEY;
-  if (!key) {
-    throw new Error("NEXT_PUBLIC_ACCESS_TOKEN_KEY is not defined");
-  }
-  return key;
-})();

--- a/frontend/app/_contexts/book.ts
+++ b/frontend/app/_contexts/book.ts
@@ -10,7 +10,7 @@ type BooksQuery = {
 export const useBooks = (query: BooksQuery) => {
   const { data, error } = useSWR<PaginatedList<Book>>(
     `/api/v1/books?limit=${query.limit}&offset=${query.offset}`,
-    (destination) => fetchWithToken(destination),
+    (destination: string) => fetchWithToken(destination),
   );
   return {
     books: data,
@@ -20,7 +20,7 @@ export const useBooks = (query: BooksQuery) => {
 };
 
 export const useBook = (id: string) => {
-  const { data, error } = useSWR<Book>(`/api/v1/books/${id}`, (destination) =>
+  const { data, error } = useSWR<Book>(`/api/v1/books/${id}`, (destination: string) =>
     fetchWithToken(destination),
   );
   return {

--- a/frontend/app/_contexts/book.ts
+++ b/frontend/app/_contexts/book.ts
@@ -1,23 +1,16 @@
 import useSWR from "swr";
-import {
-  Book,
-  PaginatedList,
-} from "../_types/book";
-import useLocalStorageState from "use-local-storage-state";
-import { ACCESS_TOKEN_KEY } from "../_components/auth";
+import { Book, PaginatedList } from "../_types/book";
 import { fetchWithToken } from "../_lib/client";
 
 type BooksQuery = {
   limit: number;
   offset: number;
-}
+};
 
 export const useBooks = (query: BooksQuery) => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
-
   const { data, error } = useSWR<PaginatedList<Book>>(
-    [`/api/v1/books?limit=${query.limit}&offset=${query.offset}`, accessToken],
-    ([destination, token]) => fetchWithToken(destination, token),
+    `/api/v1/books?limit=${query.limit}&offset=${query.offset}`,
+    (destination) => fetchWithToken(destination),
   );
   return {
     books: data,
@@ -27,10 +20,8 @@ export const useBooks = (query: BooksQuery) => {
 };
 
 export const useBook = (id: string) => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
-  const { data, error } = useSWR<Book>(
-    [`/api/v1/books/${id}`, accessToken],
-    ([destination, token]) => fetchWithToken(destination, token),
+  const { data, error } = useSWR<Book>(`/api/v1/books/${id}`, (destination) =>
+    fetchWithToken(destination),
   );
   return {
     book: data,

--- a/frontend/app/_contexts/checkout.ts
+++ b/frontend/app/_contexts/checkout.ts
@@ -5,7 +5,7 @@ import { Checkout } from "../_types/book";
 export const useMyCheckouts = () => {
   const { data, error } = useSWR<{ items: Checkout[] }>(
     "/api/v1/users/me/checkouts",
-    (destination) => fetchWithToken(destination),
+    (destination: string) => fetchWithToken(destination),
   );
   return {
     checkouts: data?.items,
@@ -17,7 +17,7 @@ export const useMyCheckouts = () => {
 export const useCheckouts = () => {
   const { data, error } = useSWR<{ items: Checkout[] }>(
     "/api/v1/books/checkouts",
-    (destination) => fetchWithToken(destination),
+    (destination: string) => fetchWithToken(destination),
   );
   return {
     checkouts: data?.items,
@@ -29,7 +29,7 @@ export const useCheckouts = () => {
 export const useBookCheckouts = (bookId: string) => {
   const { data, error } = useSWR<{ items: Checkout[] }>(
     `/api/v1/books/${bookId}/checkout-history`,
-    (destination) => fetchWithToken(destination),
+    (destination: string) => fetchWithToken(destination),
   );
   return {
     checkouts: data?.items,

--- a/frontend/app/_contexts/checkout.ts
+++ b/frontend/app/_contexts/checkout.ts
@@ -1,14 +1,11 @@
 import useSWR from "swr";
-import useLocalStorageState from "use-local-storage-state";
-import { ACCESS_TOKEN_KEY } from "../_components/auth";
 import { fetchWithToken } from "../_lib/client";
 import { Checkout } from "../_types/book";
 
 export const useMyCheckouts = () => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const { data, error } = useSWR<{ items: Checkout[] }>(
-    ["/api/v1/users/me/checkouts", accessToken],
-    ([destination, token]) => fetchWithToken(destination, token),
+    "/api/v1/users/me/checkouts",
+    (destination) => fetchWithToken(destination),
   );
   return {
     checkouts: data?.items,
@@ -18,10 +15,9 @@ export const useMyCheckouts = () => {
 };
 
 export const useCheckouts = () => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const { data, error } = useSWR<{ items: Checkout[] }>(
-    ["/api/v1/books/checkouts", accessToken],
-    ([destination, token]) => fetchWithToken(destination, token),
+    "/api/v1/books/checkouts",
+    (destination) => fetchWithToken(destination),
   );
   return {
     checkouts: data?.items,
@@ -31,10 +27,9 @@ export const useCheckouts = () => {
 };
 
 export const useBookCheckouts = (bookId: string) => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const { data, error } = useSWR<{ items: Checkout[] }>(
-    [`/api/v1/books/${bookId}/checkout-history`, accessToken],
-    ([destination, token]) => fetchWithToken(destination, token),
+    `/api/v1/books/${bookId}/checkout-history`,
+    (destination) => fetchWithToken(destination),
   );
   return {
     checkouts: data?.items,

--- a/frontend/app/_contexts/user.ts
+++ b/frontend/app/_contexts/user.ts
@@ -15,7 +15,7 @@ export const useLogout = () => {
 };
 
 export const useCurrentUser = () => {
-  const { data, error } = useSWR<User>("/api/v1/users/me", (destination) =>
+  const { data, error } = useSWR<User>("/api/v1/users/me", (destination: string) =>
     fetchWithToken(destination),
   );
   return {
@@ -26,7 +26,7 @@ export const useCurrentUser = () => {
 };
 
 export const useUsers = () => {
-  const { data, error } = useSWR<Users>("/api/v1/users", (destination) =>
+  const { data, error } = useSWR<Users>("/api/v1/users", (destination: string) =>
     fetchWithToken(destination),
   );
   return {

--- a/frontend/app/_contexts/user.ts
+++ b/frontend/app/_contexts/user.ts
@@ -1,16 +1,13 @@
 import useSWR from "swr";
-import useLocalStorageState from "use-local-storage-state";
-import { ACCESS_TOKEN_KEY } from "../_components/auth";
 import { fetchWithToken, post } from "../_lib/client";
 import { User, Users } from "../_types/user";
 import { useRouter } from "next/navigation";
 
 export const useLogout = () => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
 
   const logout = async () => {
-    await post({ destination: "/auth/logout", token: accessToken });
+    await post({ destination: "/auth/logout" });
     router.push("/login");
   };
 
@@ -18,10 +15,8 @@ export const useLogout = () => {
 };
 
 export const useCurrentUser = () => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
-  const { data, error } = useSWR<User>(
-    ["/api/v1/users/me", accessToken],
-    ([destination, token]) => fetchWithToken(destination, token),
+  const { data, error } = useSWR<User>("/api/v1/users/me", (destination) =>
+    fetchWithToken(destination),
   );
   return {
     currentUser: data,
@@ -31,10 +26,8 @@ export const useCurrentUser = () => {
 };
 
 export const useUsers = () => {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
-  const { data, error } = useSWR<Users>(
-    ["/api/v1/users", accessToken],
-    ([destination, token]) => fetchWithToken(destination, token),
+  const { data, error } = useSWR<Users>("/api/v1/users", (destination) =>
+    fetchWithToken(destination),
   );
   return {
     users: data,

--- a/frontend/app/_lib/client.ts
+++ b/frontend/app/_lib/client.ts
@@ -1,9 +1,13 @@
 export const fetchWithToken = async (destination: string) => {
-  return fetcher(destination, {
+  const res = await fetcher(destination, {
     headers: {
       "Content-Type": "application/json",
     },
-  }).then((res) => res.json());
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP error! status: ${res.status}`);
+  }
+  return res.json();
 };
 
 const fetcher = async (destination: string, init: RequestInit) => {

--- a/frontend/app/_lib/client.ts
+++ b/frontend/app/_lib/client.ts
@@ -1,10 +1,6 @@
-export const fetchWithToken = async (
-  destination: string,
-  token: string | unknown,
-) => {
+export const fetchWithToken = async (destination: string) => {
   return fetcher(destination, {
     headers: {
-      Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
   }).then((res) => res.json());
@@ -12,12 +8,16 @@ export const fetchWithToken = async (
 
 const fetcher = async (destination: string, init: RequestInit) => {
   const res = await fetch(
-    `${process.env.API_ROOT_PROTOCOL ?? "http"}://${process.env.API_ROOT_URL?.replace(/\/$/g, "") ?? "localhost"
+    `${process.env.API_ROOT_PROTOCOL ?? "http"}://${
+      process.env.API_ROOT_URL?.replace(/\/$/g, "") ?? "localhost"
     }:${process.env.API_ROOT_PORT ?? "8080"}/${destination.replace(
       /^\//g,
       "",
     )}`,
-    init,
+    {
+      ...init,
+      credentials: "include",
+    },
   );
 
   return res;
@@ -25,7 +25,6 @@ const fetcher = async (destination: string, init: RequestInit) => {
 
 type RequestInfo<T> = {
   destination: string;
-  token?: string | unknown;
   body?: T;
 };
 
@@ -33,12 +32,9 @@ const sender = async <T>(
   info: RequestInfo<T>,
   method: "POST" | "PUT" | "DELETE",
 ) => {
-  const basicHeaders = {
+  const headers = {
     "Content-Type": "application/json",
   };
-  const headers = info.token
-    ? { Authorization: `Bearer ${info.token}`, ...basicHeaders }
-    : basicHeaders;
   const basicInit = {
     method: method,
     headers: headers,

--- a/frontend/app/books/[id]/edit/page.tsx
+++ b/frontend/app/books/[id]/edit/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import Header from "@/app/_components/Header";
 import { useBook } from "@/app/_contexts/book";
 import { useLogout } from "@/app/_contexts/user";
@@ -17,14 +16,12 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import useLocalStorageState from "use-local-storage-state";
 
 export default function EditBook({
   params,
 }: Readonly<{
   params: { id: string };
 }>) {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
   const { logout } = useLogout();
 
@@ -49,7 +46,6 @@ export default function EditBook({
     e.preventDefault();
     const res = await put({
       destination: `/api/v1/books/${params.id}`,
-      token: accessToken,
       body: input,
     });
 

--- a/frontend/app/books/[id]/page.tsx
+++ b/frontend/app/books/[id]/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import Header from "@/app/_components/Header";
 import { DeleteIcon, EditIcon } from "@chakra-ui/icons";
 import {
@@ -24,7 +23,6 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useRef } from "react";
-import useLocalStorageState from "use-local-storage-state";
 import NextLink from "next/link";
 import { useBook } from "@/app/_contexts/book";
 import { useLogout } from "@/app/_contexts/user";
@@ -33,7 +31,6 @@ import CheckoutButton from "@/app/_components/CheckoutButton";
 import CheckoutHistory from "@/app/_components/CheckoutHistory";
 
 export default function Page({ params }: Readonly<{ params: { id: string } }>) {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
   const { logout } = useLogout();
   const {
@@ -49,7 +46,6 @@ export default function Page({ params }: Readonly<{ params: { id: string } }>) {
     e.preventDefault();
     const res = await del({
       destination: `/api/v1/books/${params.id}`,
-      token: accessToken,
     });
     if (res.ok) {
       router.push("/");

--- a/frontend/app/books/create/page.tsx
+++ b/frontend/app/books/create/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import Header from "@/app/_components/Header";
 import { useLogout } from "@/app/_contexts/user";
 import { post } from "@/app/_lib/client";
@@ -16,7 +15,6 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { SubmitHandler, useForm } from "react-hook-form";
-import useLocalStorageState from "use-local-storage-state";
 
 type BookInput = {
   title: string;
@@ -26,7 +24,6 @@ type BookInput = {
 };
 
 export default function CreateBook() {
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
   const { logout } = useLogout();
 
@@ -39,7 +36,6 @@ export default function CreateBook() {
   const onSubmit: SubmitHandler<BookInput> = async (values) => {
     const res = await post({
       destination: "/api/v1/books",
-      token: accessToken,
       body: values,
     });
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -20,8 +20,6 @@ import {
 import { useState } from "react";
 import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
 import { useRouter } from "next/navigation";
-import { ACCESS_TOKEN_KEY } from "../_components/auth";
-import useLocalStorageState from "use-local-storage-state";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { post } from "../_lib/client";
 
@@ -34,7 +32,6 @@ export default function Login() {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const router = useRouter();
-  const [_accessToken, setAccessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
 
   const {
     handleSubmit,
@@ -46,8 +43,6 @@ export default function Login() {
     const res = await post({ destination: "/auth/login", body: input });
 
     if (res.ok) {
-      const json = await res.json();
-      setAccessToken(json.accessToken);
       router.push("/");
     } else {
       setError("メールアドレスまたはパスワードが間違っています。");

--- a/frontend/app/users/password/page.tsx
+++ b/frontend/app/users/password/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ACCESS_TOKEN_KEY } from "@/app/_components/auth";
 import Header from "@/app/_components/Header";
 import { useLogout } from "@/app/_contexts/user";
 import {
@@ -18,7 +17,6 @@ import { useState } from "react";
 import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
 import { useRouter } from "next/navigation";
 import { SubmitHandler, useForm } from "react-hook-form";
-import useLocalStorageState from "use-local-storage-state";
 import { put } from "@/app/_lib/client";
 
 type UserPasswordInput = {
@@ -29,7 +27,6 @@ type UserPasswordInput = {
 export default function UpdateUserPassword() {
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
-  const [accessToken] = useLocalStorageState(ACCESS_TOKEN_KEY);
   const router = useRouter();
   const { logout } = useLogout();
   const toast = useToast();
@@ -43,7 +40,6 @@ export default function UpdateUserPassword() {
   const onSubmit: SubmitHandler<UserPasswordInput> = async (values) => {
     const res = await put({
       destination: "/api/v1/users/me/password",
-      token: accessToken,
       body: values,
     });
 

--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -99,7 +99,8 @@ async fn bootstrap() -> Result<()> {
                 .unwrap_or_else(|_| "http://localhost:3000".into())
                 .parse::<axum::http::HeaderValue>()
                 .unwrap(),
-        );
+        )
+        .allow_credentials(true);
 
     let router = Router::new().merge(v1::routes()).merge(auth::routes());
     // デバッグビルドの時は, ReDocによるAPIドキュメント出力を有効にする


### PR DESCRIPTION
Migrated from localStorage to HttpOnly cookies for access token storage to mitigate XSS risks. Updated backend CORS, handlers, and request extractor; updated frontend API client and authentication hooks.

---
*PR created automatically by Jules for task [10234133002821408842](https://jules.google.com/task/10234133002821408842) started by @kurousa*