### PR TITLE
⚡ Optimize bcrypt operations with spawn_blocking

### DIFF
--- a/adapter/src/repository/auth.rs
+++ b/adapter/src/repository/auth.rs
@@ -51,7 +51,11 @@ impl AuthRepository for AuthRepositoryImpl {
         .await
         .map_err(AppError::DatabaseOperationError)?;
 
-        let valid = bcrypt::verify(password, &user_item.password_hash)?;
+        let password = password.to_string();
+        let hash = user_item.password_hash;
+        let valid = tokio::task::spawn_blocking(move || bcrypt::verify(password, &hash))
+            .await
+            .map_err(|e| AppError::InternalError(e.into()))??;
 
         if !valid {
             return Err(AppError::UnauthenticatedError);

--- a/adapter/src/repository/user.rs
+++ b/adapter/src/repository/user.rs
@@ -79,7 +79,7 @@ impl UserRepository for UserRepositoryImpl {
 
     async fn create(&self, event: CreateUser) -> AppResult<User> {
         let user_id = UserId::new();
-        let hashed_password = hash_password(&event.password)?;
+        let hashed_password = hash_password(&event.password).await?;
         let role = Role::User;
 
         let res = sqlx::query!(
@@ -127,10 +127,10 @@ impl UserRepository for UserRepositoryImpl {
         .password_hash;
 
         // 現在のパスワードが正しいか検証
-        verify_password(&event.current_password, &original_password_hash)?;
+        verify_password(&event.current_password, &original_password_hash).await?;
 
         // 新しいパスワードのハッシュ値で更新
-        let new_password_hash = hash_password(&event.new_password)?;
+        let new_password_hash = hash_password(&event.new_password).await?;
         sqlx::query!(
             r#"
                 UPDATE users SET password_hash = $2 WHERE user_id = $1;
@@ -189,12 +189,23 @@ impl UserRepository for UserRepositoryImpl {
     }
 }
 
-fn hash_password(password: &str) -> AppResult<String> {
-    bcrypt::hash(password, bcrypt::DEFAULT_COST).map_err(AppError::from)
+async fn hash_password(password: &str) -> AppResult<String> {
+    let password = password.to_string();
+    tokio::task::spawn_blocking(move || {
+        bcrypt::hash(password, bcrypt::DEFAULT_COST).map_err(AppError::from)
+    })
+    .await
+    .map_err(|e| AppError::InternalError(e.into()))?
 }
 
-fn verify_password(password: &str, hash: &str) -> AppResult<()> {
-    if !bcrypt::verify(password, hash)? {
+async fn verify_password(password: &str, hash: &str) -> AppResult<()> {
+    let password = password.to_string();
+    let hash = hash.to_string();
+    let valid = tokio::task::spawn_blocking(move || bcrypt::verify(password, &hash))
+        .await
+        .map_err(|e| AppError::InternalError(e.into()))??;
+
+    if !valid {
         return Err(AppError::UnauthenticatedError);
     }
     Ok(())


### PR DESCRIPTION
This PR optimizes the performance of the application by offloading CPU-intensive `bcrypt` hashing and verification operations to `tokio::task::spawn_blocking`.

💡 **What:** 
Modified `adapter/src/repository/user.rs` and `adapter/src/repository/auth.rs` to wrap `bcrypt::hash` and `bcrypt::verify` calls in `tokio::task::spawn_blocking`. The `hash_password` and `verify_password` helper functions in `user.rs` were made `async`, and their callers were updated accordingly.

🎯 **Why:**
Bcrypt operations are computationally expensive by design and block the thread they run on for a significant amount of time (often >100ms depending on cost). In an `async` context, this stalls the Tokio runtime's worker threads, preventing other tasks from being executed and reducing the overall concurrency and responsiveness of the service.

📊 **Measured Improvement:**
While environment constraints (restricted network and incomplete offline cache) prevented running a full benchmark suite or `cargo check` at the workspace level, the rationale for this change is a well-established best practice in the Rust async ecosystem. Offloading these tasks ensures that the async executor remains free to handle I/O and other concurrent requests.


---
*PR created automatically by Jules for task [3898912932536819896](https://jules.google.com/task/3898912932536819896) started by @kurousa*