### PR TITLE
🔒 Restrict overly permissive CORS headers

### DIFF
--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -15,7 +15,7 @@ use registry::AppRegistryImpl;
 use shared::config::AppConfig;
 use tokio::net::TcpListener;
 use tower_http::{
-    cors::{self, CorsLayer},
+    cors::CorsLayer,
     trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
     LatencyUnit,
 };
@@ -96,7 +96,7 @@ async fn bootstrap() -> Result<()> {
         .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
         // allow `GET`,`POST`,`PUT`,`DELETE` when accessing the resource
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
-        // allow requests from any origin
+        // allow requests from the specified origin
         .allow_origin(
             std::env::var("FRONTEND_URL")
                 .unwrap_or_else(|_| "http://localhost:3000".into())

--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -6,7 +6,10 @@ use std::{
 use adapter::{database::connect_database_with, redis::RedisClient};
 use anyhow::{Context, Result};
 use api::route::{auth, v1};
-use axum::{http::Method, Router};
+use axum::{
+    http::{header, Method},
+    Router,
+};
 use opentelemetry::global;
 use registry::AppRegistryImpl;
 use shared::config::AppConfig;
@@ -89,8 +92,8 @@ async fn bootstrap() -> Result<()> {
     // registryの初期化
     let registry = Arc::new(AppRegistryImpl::new(pool, kv, app_config));
     let cors = CorsLayer::new()
-        // allow Any headers when accessing the resource
-        .allow_headers(cors::Any)
+        // allow `Authorization` and `Content-Type` headers when accessing the resource
+        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
         // allow `GET`,`POST`,`PUT`,`DELETE` when accessing the resource
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
         // allow requests from any origin


### PR DESCRIPTION
The application previously used `cors::Any` for its CORS allowed headers configuration, which is overly permissive and considered a security vulnerability. This change restricts the allowed headers to only those strictly necessary for the application's functionality: `Authorization` (for bearer tokens) and `Content-Type` (for JSON requests).

I have verified that:
1. `src/bin/app.rs` correctly imports `axum::http::header`.
2. The `CorsLayer` configuration now uses `.allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])`.
3. The frontend's fetcher (`frontend/app/_lib/client.ts`) uses these headers.

While I attempted to run `cargo check`, environment issues (missing toolchain 1.93.0 and offline registry limitations) prevented successful execution. However, the change is minimal and has been verified through careful code inspection and a successful code review.

---
*PR created automatically by Jules for task [1447011217247927153](https://jules.google.com/task/1447011217247927153) started by @kurousa*