### PR TITLE
🧹 replace unwrap() with ? in RedisConfig test

### DIFF
--- a/adapter/src/redis/mod.rs
+++ b/adapter/src/redis/mod.rs
@@ -76,8 +76,8 @@ mod tests {
     #[sqlx::test]
     async fn test_con() -> anyhow::Result<()> {
         let config = RedisConfig {
-            host: std::env::var("REDIS_HOST").unwrap(),
-            port: std::env::var("REDIS_PORT").unwrap().parse().unwrap(),
+            host: std::env::var("REDIS_HOST")?,
+            port: std::env::var("REDIS_PORT")?.parse()?,
         };
         let client = RedisClient::new(&config)?;
 


### PR DESCRIPTION
This PR improves the code health of the `adapter` crate by removing `unwrap()` calls from a test function.

🎯 **What:** Replaced `std::env::var(...).unwrap()` and `.parse().unwrap()` with the `?` operator in `adapter/src/redis/mod.rs:test_con`.
💡 **Why:** Using `?` for error propagation is more idiomatic in Rust when the function returns a `Result`. It provides better error messages and avoids panics during test execution.
✅ **Verification:** Manually verified the changes with `read_file`. Attempted to run tests with `cargo test`, though local environment issues with toolchains and offline dependencies limited full automated execution.
✨ **Result:** Improved maintainability and idiomatic error handling in the test suite.

---
*PR created automatically by Jules for task [10311171125025643185](https://jules.google.com/task/10311171125025643185) started by @kurousa*