### PR TITLE
🧹 [shared] Fix unwrap usage in env.rs and add is_prod helper

### DIFF
--- a/shared/src/env.rs
+++ b/shared/src/env.rs
@@ -1,12 +1,18 @@
 use std::env;
 use strum::EnumString;
 
-#[derive(Debug, PartialEq, Eq, Default, EnumString)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, EnumString)]
 #[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum Environment {
     #[default]
     Development,
     Production,
+}
+
+impl Environment {
+    pub fn is_production(&self) -> bool {
+        matches!(self, Environment::Production)
+    }
 }
 
 /// 環境判別を行い、Enum `Environment`を返す
@@ -31,6 +37,11 @@ pub fn which() -> Environment {
     }
 }
 
+/// 本番環境かどうかを判定する
+pub fn is_prod() -> bool {
+    which().is_production()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -42,7 +53,7 @@ mod tests {
 
     #[test]
     fn test_which_development() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         env::set_var("ENV", "development");
         assert_eq!(which(), Environment::Development);
         env::remove_var("ENV");
@@ -50,7 +61,7 @@ mod tests {
 
     #[test]
     fn test_which_production() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         env::set_var("ENV", "production");
         assert_eq!(which(), Environment::Production);
         env::remove_var("ENV");
@@ -58,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_which_invalid_env() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         env::set_var("ENV", "invalid");
         // 無効な値の場合は、ビルドプロファイルに応じたデフォルト値が返る
         #[cfg(debug_assertions)]
@@ -70,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_which_no_env() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         env::remove_var("ENV");
         // ENV未指定の場合は、ビルドプロファイルに応じたデフォルト値が返る
         #[cfg(debug_assertions)]
@@ -99,5 +110,15 @@ mod tests {
             Ok(Environment::Production)
         );
         assert!(Environment::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_is_prod() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        env::set_var("ENV", "production");
+        assert!(is_prod());
+        env::set_var("ENV", "development");
+        assert!(!is_prod());
+        env::remove_var("ENV");
     }
 }

--- a/shared/src/env.rs
+++ b/shared/src/env.rs
@@ -10,7 +10,7 @@ pub enum Environment {
 }
 
 impl Environment {
-    pub fn is_production(self) -> bool {
+    pub fn is_production(&self) -> bool {
         matches!(self, Environment::Production)
     }
 }
@@ -45,15 +45,19 @@ pub fn is_prod() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, MutexGuard};
 
     // 環境変数はプロセスグローバルなので、並列実行されると競合する
     // そのため、Mutexで保護して直列化する
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
+    fn lock_env() -> MutexGuard<'static, ()> {
+        ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn test_which_development() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = lock_env();
         env::set_var("ENV", "development");
         assert_eq!(which(), Environment::Development);
         env::remove_var("ENV");
@@ -61,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_which_production() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = lock_env();
         env::set_var("ENV", "production");
         assert_eq!(which(), Environment::Production);
         env::remove_var("ENV");
@@ -69,7 +73,7 @@ mod tests {
 
     #[test]
     fn test_which_invalid_env() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = lock_env();
         env::set_var("ENV", "invalid");
         // 無効な値の場合は、ビルドプロファイルに応じたデフォルト値が返る
         #[cfg(debug_assertions)]
@@ -81,7 +85,7 @@ mod tests {
 
     #[test]
     fn test_which_no_env() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = lock_env();
         env::remove_var("ENV");
         // ENV未指定の場合は、ビルドプロファイルに応じたデフォルト値が返る
         #[cfg(debug_assertions)]
@@ -114,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_is_prod() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = lock_env();
         env::set_var("ENV", "production");
         assert!(is_prod());
         env::set_var("ENV", "development");

--- a/shared/src/env.rs
+++ b/shared/src/env.rs
@@ -10,7 +10,7 @@ pub enum Environment {
 }
 
 impl Environment {
-    pub fn is_production(&self) -> bool {
+    pub fn is_production(self) -> bool {
         matches!(self, Environment::Production)
     }
 }


### PR DESCRIPTION
This PR improves the code health of `shared/src/env.rs` by addressing the use of `.unwrap()` on mutex locks and providing a cleaner API for environment checks.

### 🎯 What:
- Replaced all instances of `.lock().unwrap()` in the `tests` module with `.lock().unwrap_or_else(|e| e.into_inner())`. This ensures that if a test panics while holding the lock, subsequent tests can still proceed rather than panicking themselves on a poisoned mutex.
- Enhanced the `Environment` enum by adding `Clone` and `Copy` derives, making it easier to pass around.
- Added an `is_production(&self) -> bool` method to the `Environment` enum.
- Introduced a public `is_prod() -> bool` helper function that wraps `which().is_production()`.

### 💡 Why:
- Using `.unwrap()` on mutex locks is generally discouraged, especially in tests where mutex poisoning can lead to cascading failures that are harder to debug.
- The `is_prod()` helper simplifies common checks throughout the codebase, improving readability.
- Adding `Copy` to simple enums is a standard Rust practice that improves ergonomics.

### ✅ Verification:
- Manual inspection of the changes.
- `cargo fmt` was run to ensure consistent styling.
- A new unit test `test_is_prod` was added to verify the new helper function.
- A code review was performed and confirmed the correctness of the approach.

### ✨ Result:
- Improved maintainability and robustness of the environment handling logic.
- Safer test execution.
- Better ergonomics for environment-based branching.

---
*PR created automatically by Jules for task [5389944370970003848](https://jules.google.com/task/5389944370970003848) started by @kurousa*