### PR TITLE
🧪 [user registration] Add error test for non-admin user registration

### DIFF
--- a/api/tests/api/main.rs
+++ b/api/tests/api/main.rs
@@ -1,3 +1,4 @@
 mod book;
 mod health;
 mod helper;
+mod user;

--- a/api/tests/api/user.rs
+++ b/api/tests/api/user.rs
@@ -1,0 +1,22 @@
+use crate::helper::{fixture, make_router, v1, TestRequestExt};
+use axum::{body::Body, http::Request};
+use rstest::rstest;
+use tower::ServiceExt;
+
+#[rstest]
+#[tokio::test]
+async fn register_user_403(fixture: registry::MockAppRegistryExt) -> anyhow::Result<()> {
+    let app = make_router(fixture);
+
+    let req = Request::post(&v1("/users"))
+        .header("Content-Type", "application/json")
+        .bearer()
+        .body(Body::from(
+            r#"{"name": "test", "email": "test@example.com", "password": "password"}"#,
+        ))?;
+    let resp = app.oneshot(req).await?;
+
+    assert_eq!(resp.status(), axum::http::StatusCode::FORBIDDEN);
+
+    Ok(())
+}

--- a/api/tests/api/user.rs
+++ b/api/tests/api/user.rs
@@ -1,4 +1,4 @@
-use crate::helper::{fixture, make_router, v1, TestRequestExt};
+use crate::helper::{fixture, fixture_auth, fixture_registry, make_router, v1, TestRequestExt};
 use axum::{body::Body, http::Request};
 use rstest::rstest;
 use tower::ServiceExt;


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error test for non-admin user registration in `register_user` handler.
📊 **Coverage:** A new integration test case `register_user_403` has been added to verify that non-admin users cannot register new users.
✨ **Result:** Increased reliability of the authorization logic in the user registration endpoint.

---
*PR created automatically by Jules for task [1442188327442437479](https://jules.google.com/task/1442188327442437479) started by @kurousa*