### PR TITLE
🔒 [security fix] Make bcrypt cost factor configurable via environment variable

### DIFF
--- a/adapter/src/repository/user.rs
+++ b/adapter/src/repository/user.rs
@@ -16,6 +16,7 @@ use crate::database::{model::user::UserRow, ConnectionPool};
 #[derive(new)]
 pub struct UserRepositoryImpl {
     db: ConnectionPool,
+    bcrypt_cost: u32,
 }
 #[async_trait]
 impl UserRepository for UserRepositoryImpl {
@@ -79,7 +80,7 @@ impl UserRepository for UserRepositoryImpl {
 
     async fn create(&self, event: CreateUser) -> AppResult<User> {
         let user_id = UserId::new();
-        let hashed_password = hash_password(&event.password).await?;
+        let hashed_password = self.hash_password(&event.password).await?;
         let role = Role::User;
 
         let res = sqlx::query!(
@@ -130,7 +131,7 @@ impl UserRepository for UserRepositoryImpl {
         verify_password(&event.current_password, &original_password_hash).await?;
 
         // 新しいパスワードのハッシュ値で更新
-        let new_password_hash = hash_password(&event.new_password).await?;
+        let new_password_hash = self.hash_password(&event.new_password).await?;
         sqlx::query!(
             r#"
                 UPDATE users SET password_hash = $2 WHERE user_id = $1;
@@ -189,13 +190,16 @@ impl UserRepository for UserRepositoryImpl {
     }
 }
 
-async fn hash_password(password: &str) -> AppResult<String> {
-    let password = password.to_string();
-    tokio::task::spawn_blocking(move || {
-        bcrypt::hash(password, bcrypt::DEFAULT_COST).map_err(AppError::from)
-    })
-    .await
-    .map_err(|e| AppError::InternalError(e.into()))?
+impl UserRepositoryImpl {
+    async fn hash_password(&self, password: &str) -> AppResult<String> {
+        let password = password.to_string();
+        let bcrypt_cost = self.bcrypt_cost;
+        tokio::task::spawn_blocking(move || {
+            bcrypt::hash(password, bcrypt_cost).map_err(AppError::from)
+        })
+        .await
+        .map_err(|e| AppError::InternalError(e.into()))?
+    }
 }
 
 async fn verify_password(password: &str, hash: &str) -> AppResult<()> {
@@ -209,4 +213,22 @@ async fn verify_password(password: &str, hash: &str) -> AppResult<()> {
         return Err(AppError::UnauthenticatedError);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::ConnectionPool;
+
+    #[tokio::test]
+    async fn test_hash_password_with_custom_cost() {
+        let repo = UserRepositoryImpl {
+            db: ConnectionPool::new(sqlx::PgPool::connect_lazy("postgres://localhost/db").unwrap()),
+            bcrypt_cost: 4,
+        };
+        let password = "password";
+        let hashed = repo.hash_password(password).await.unwrap();
+        let cost = bcrypt::get_cost(&hashed).unwrap();
+        assert_eq!(cost, 4);
+    }
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,3 +1,4 @@
+
 pub mod extractor;
 pub mod handler;
 pub mod model;

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -39,7 +39,10 @@ impl AppRegistryImpl {
             redis_client.clone(),
             app_config.auth.ttl,
         ));
-        let user_repository = Arc::new(UserRepositoryImpl::new(pool.clone()));
+        let user_repository = Arc::new(UserRepositoryImpl::new(
+            pool.clone(),
+            app_config.auth.bcrypt_cost,
+        ));
         let check_out_repository = Arc::new(CheckoutRepositoryImpl::new(pool.clone()));
         Self {
             health_check_repository,

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -21,6 +21,9 @@ impl AppConfig {
         };
         let auth = AuthConfig {
             ttl: std::env::var("AUTH_TOKEN_TTL")?.parse::<u64>()?,
+            bcrypt_cost: std::env::var("BCRYPT_COST")
+                .map(|v| v.parse().unwrap_or(bcrypt::DEFAULT_COST))
+                .unwrap_or(bcrypt::DEFAULT_COST),
         };
         Ok(Self {
             database,
@@ -45,4 +48,5 @@ pub struct RedisConfig {
 
 pub struct AuthConfig {
     pub ttl: u64,
+    pub bcrypt_cost: u32,
 }


### PR DESCRIPTION
🎯 **What:** The bcrypt cost factor, previously hardcoded to `bcrypt::DEFAULT_COST`, is now configurable via the `BCRYPT_COST` environment variable.

⚠️ **Risk:** Hardcoded security parameters make it difficult to respond to evolving security requirements or hardware improvements that might necessitate a higher work factor. If the default factor becomes too low due to increased computing power, passwords could be more easily brute-forced if the database is compromised.

🛡️ **Solution:** 
1. Added a `bcrypt_cost` field to `AuthConfig` in `shared/src/config.rs`, which reads from the `BCRYPT_COST` environment variable with a fallback to `bcrypt::DEFAULT_COST`.
2. Modified `UserRepositoryImpl` in `adapter/src/repository/user.rs` to store and use this `bcrypt_cost` during password hashing.
3. Updated the dependency injection in `registry/src/lib.rs` to pass the configured cost from `AppConfig` to the repository.
4. Added a unit test in `adapter/src/repository/user.rs` to ensure that a custom cost factor is correctly applied to generated hashes.

---
*PR created automatically by Jules for task [2853350228339540876](https://jules.google.com/task/2853350228339540876) started by @kurousa*