### PR TITLE
⚡ [performance optimization: combine paginated book queries]

### DIFF
--- a/adapter/src/database/model/book.rs
+++ b/adapter/src/database/model/book.rs
@@ -44,6 +44,44 @@ pub struct PaginatedBookRow {
     pub total: i64,
     pub id: BookId,
 }
+
+pub struct PaginatedBookDetailRow {
+    pub total: i64,
+    pub book_id: BookId,
+    pub title: String,
+    pub author: String,
+    pub isbn: String,
+    pub description: String,
+    pub owned_by: UserId,
+    pub owner_name: String,
+}
+
+impl PaginatedBookDetailRow {
+    pub fn into_book(self, checkout: Option<CheckoutInfo>) -> Book {
+        let PaginatedBookDetailRow {
+            book_id,
+            title,
+            author,
+            isbn,
+            description,
+            owned_by,
+            owner_name,
+            ..
+        } = self;
+        Book {
+            id: book_id,
+            title,
+            author,
+            isbn,
+            description,
+            owner: BookOwner {
+                id: owned_by,
+                name: owner_name,
+            },
+            checkout_info: checkout,
+        }
+    }
+}
 ///貸出し情報を含めた本のレコード型定義
 pub struct BookCheckoutRow {
     pub checkout_id: CheckoutId,

--- a/adapter/src/repository/book.rs
+++ b/adapter/src/repository/book.rs
@@ -13,7 +13,9 @@ use kernel::{
 };
 use shared::error::{AppError, AppResult};
 
-use crate::database::model::book::{BookCheckoutRow, BookRow, PaginatedBookRow};
+use crate::database::model::book::{
+    BookCheckoutRow, BookRow, PaginatedBookDetailRow, PaginatedBookRow,
+};
 use crate::database::ConnectionPool;
 use std::collections::HashMap;
 
@@ -82,14 +84,21 @@ impl BookRepository for BookRepositoryImpl {
     async fn find_all(&self, options: BookListOptions) -> AppResult<PaginatedList<Book>> {
         let BookListOptions { limit, offset } = options;
 
-        let rows: Vec<PaginatedBookRow> = sqlx::query_as!(
-            PaginatedBookRow,
+        let rows: Vec<PaginatedBookDetailRow> = sqlx::query_as!(
+            PaginatedBookDetailRow,
             r#"
                 SELECT
                     COUNT(*) OVER() AS "total!",
-                    b.book_id AS id
+                    b.book_id AS book_id,
+                    b.title AS title,
+                    b.author AS author,
+                    b.isbn AS isbn,
+                    b.description AS description,
+                    u.user_id AS owned_by,
+                    u.name AS owner_name
                 FROM books AS b
-                ORDER BY created_at DESC
+                INNER JOIN users AS u USING(user_id)
+                ORDER BY b.created_at DESC
                 LIMIT $1
                 OFFSET $2
             "#,
@@ -101,29 +110,7 @@ impl BookRepository for BookRepositoryImpl {
         .map_err(AppError::DatabaseOperationError)?;
 
         let total = rows.first().map(|r| r.total).unwrap_or_default();
-        let book_ids = rows.into_iter().map(|r| r.id).collect::<Vec<BookId>>();
-
-        let rows: Vec<BookRow> = sqlx::query_as!(
-            BookRow,
-            r#"
-                SELECT
-                    b.book_id AS book_id,
-                    b.title AS title,
-                    b.author AS author,
-                    b.isbn AS isbn,
-                    b.description AS description,
-                    u.user_id AS owned_by,
-                    u.name AS owner_name
-                FROM books AS b
-                INNER JOIN users AS u USING(user_id)
-                WHERE b.book_id IN (SELECT * FROM UNNEST($1::uuid[]))
-                ORDER BY b.created_at DESC
-            "#,
-            &book_ids as _
-        )
-        .fetch_all(self.db.inner_ref())
-        .await
-        .map_err(AppError::DatabaseOperationError)?;
+        let book_ids: Vec<BookId> = rows.iter().map(|r| r.book_id).collect();
 
         let mut checkouts = self.find_checkouts(&book_ids).await?;
         let items = rows


### PR DESCRIPTION
💡 **What:**
Combined the total count query and the paginated data retrieval query in `BookRepositoryImpl::find_all` into a single SQL query using the PostgreSQL window function `COUNT(*) OVER()`. Introduced a new struct `PaginatedBookDetailRow` in `adapter/src/database/model/book.rs` to handle the combined result set.

🎯 **Why:**
The previous implementation performed two separate database round-trips for every paginated list request: one to get the total count and book IDs, and another to fetch the full book details. Combining these queries reduces network latency and database overhead, leading to faster response times for the book list API.

📊 **Measured Improvement:**
I was unable to perform live benchmarks due to environment restrictions (offline mode and missing dependencies preventing compilation/execution of tests). However, this change provides a clear theoretical improvement by reducing the number of database round-trips from 2 to 1 (excluding the separate checkout info fetch), which is a significant latency reduction in typical network-partitioned application architectures.

---
*PR created automatically by Jules for task [11658631020909016419](https://jules.google.com/task/11658631020909016419) started by @kurousa*