### PR TITLE
⚡ optimize: eliminate N+1 queries during paginated book retrieval

### DIFF
--- a/adapter/src/database/model/book.rs
+++ b/adapter/src/database/model/book.rs
@@ -54,10 +54,33 @@ pub struct PaginatedBookDetailRow {
     pub description: String,
     pub owned_by: UserId,
     pub owner_name: String,
+    pub checkout_id: Option<CheckoutId>,
+    pub checkout_user_id: Option<UserId>,
+    pub checkout_user_name: Option<String>,
+    pub checked_out_at: Option<DateTime<Utc>>,
 }
 
 impl PaginatedBookDetailRow {
-    pub fn into_book(self, checkout: Option<CheckoutInfo>) -> Book {
+    pub fn into_book(self) -> Book {
+        let checkout =
+            if let (Some(checkout_id), Some(user_id), Some(user_name), Some(checked_out_at)) = (
+                self.checkout_id,
+                self.checkout_user_id,
+                self.checkout_user_name,
+                self.checked_out_at,
+            ) {
+                Some(CheckoutInfo {
+                    checkout_id,
+                    checked_out_by: CheckOutUser {
+                        id: user_id,
+                        name: user_name,
+                    },
+                    checked_out_at,
+                })
+            } else {
+                None
+            };
+
         let PaginatedBookDetailRow {
             book_id,
             title,

--- a/adapter/src/repository/book.rs
+++ b/adapter/src/repository/book.rs
@@ -95,9 +95,15 @@ impl BookRepository for BookRepositoryImpl {
                     b.isbn AS isbn,
                     b.description AS description,
                     u.user_id AS owned_by,
-                    u.name AS owner_name
+                    u.name AS owner_name,
+                    c.checkout_id AS "checkout_id?",
+                    cu.user_id AS "checkout_user_id?",
+                    cu.name AS "checkout_user_name?",
+                    c.checked_out_at AS "checked_out_at?"
                 FROM books AS b
                 INNER JOIN users AS u USING(user_id)
+                LEFT JOIN checkouts AS c ON b.book_id = c.book_id
+                LEFT JOIN users AS cu ON c.user_id = cu.user_id
                 ORDER BY b.created_at DESC
                 LIMIT $1
                 OFFSET $2
@@ -110,15 +116,9 @@ impl BookRepository for BookRepositoryImpl {
         .map_err(AppError::DatabaseOperationError)?;
 
         let total = rows.first().map(|r| r.total).unwrap_or_default();
-        let book_ids: Vec<BookId> = rows.iter().map(|r| r.book_id).collect();
-
-        let mut checkouts = self.find_checkouts(&book_ids).await?;
         let items = rows
             .into_iter()
-            .map(|row| {
-                let checkout = checkouts.remove(&row.book_id);
-                row.into_book(checkout)
-            })
+            .map(|row: PaginatedBookDetailRow| row.into_book())
             .collect();
 
         Ok(PaginatedList {

--- a/commit.md
+++ b/commit.md
@@ -1,0 +1,5 @@
+⚡ optimize: eliminate N+1 queries during paginated book retrieval
+
+💡 What: Modified `find_all` in `BookRepositoryImpl` to use `LEFT JOIN`s for checkouts and checkout users, directly mapping the result into the returned `Book` instead of making a second sequential query via `find_checkouts`.
+🎯 Why: Previously, `find_all` would execute a query to fetch a paginated list of books, and then execute a second query (`find_checkouts`) to look up the checkout status for all the retrieved book IDs using an `IN` clause. This resulted in redundant database roundtrips, increasing latency. By combining them via `LEFT JOIN`, we execute everything in one database roundtrip and rely on the database's optimizer to resolve it efficiently.
+📊 Measured Improvement: Due to environment constraints with `sqlx` prepare checks and local database setup, automated benchmarking was not run successfully. However, theoretical benefits for I/O bound tasks point to a 1 roundtrip reduction per page load (eliminating the N+1 `IN` clause fetching behavior) which decreases overall latency.

--- a/commit.md
+++ b/commit.md
@@ -1,5 +1,0 @@
-⚡ optimize: eliminate N+1 queries during paginated book retrieval
-
-💡 What: Modified `find_all` in `BookRepositoryImpl` to use `LEFT JOIN`s for checkouts and checkout users, directly mapping the result into the returned `Book` instead of making a second sequential query via `find_checkouts`.
-🎯 Why: Previously, `find_all` would execute a query to fetch a paginated list of books, and then execute a second query (`find_checkouts`) to look up the checkout status for all the retrieved book IDs using an `IN` clause. This resulted in redundant database roundtrips, increasing latency. By combining them via `LEFT JOIN`, we execute everything in one database roundtrip and rely on the database's optimizer to resolve it efficiently.
-📊 Measured Improvement: Due to environment constraints with `sqlx` prepare checks and local database setup, automated benchmarking was not run successfully. However, theoretical benefits for I/O bound tasks point to a 1 roundtrip reduction per page load (eliminating the N+1 `IN` clause fetching behavior) which decreases overall latency.


### PR DESCRIPTION
💡 What: Modified `find_all` in `BookRepositoryImpl` to use `LEFT JOIN`s for checkouts and checkout users, directly mapping the result into the returned `Book` instead of making a second sequential query via `find_checkouts`.
🎯 Why: Previously, `find_all` would execute a query to fetch a paginated list of books, and then execute a second query (`find_checkouts`) to look up the checkout status for all the retrieved book IDs using an `IN` clause. This resulted in redundant database roundtrips, increasing latency. By combining them via `LEFT JOIN`, we execute everything in one database roundtrip and rely on the database's optimizer to resolve it efficiently.
📊 Measured Improvement: Due to environment constraints with `sqlx` prepare checks and local database setup, automated benchmarking was not run successfully. However, theoretical benefits for I/O bound tasks point to a 1 roundtrip reduction per page load (eliminating the N+1 `IN` clause fetching behavior) which decreases overall latency.

---
*PR created automatically by Jules for task [2025223017281447660](https://jules.google.com/task/2025223017281447660) started by @kurousa*